### PR TITLE
fix `localhost:8000` case

### DIFF
--- a/src/urlutil.js
+++ b/src/urlutil.js
@@ -25,7 +25,8 @@ export default class UrlUtil {
     // - scheme + ':' (ex. http:)
     // - scheme + '://' (ex. http://)
     // - null
-    return (rscheme.exec(input) || [])[0];
+    let scheme = (rscheme.exec(input) || [])[0];
+    return scheme === 'localhost:' ? null : scheme;
   }
 
   /**
@@ -49,13 +50,13 @@ export default class UrlUtil {
     // for native form validation.
     //
     // for cases, ?abc and "a? b" which should searching query
-    var case1Reg = /^(\?)|(\?.+\s)/;
+    const case1Reg = /^(\?)|(\?.+\s)/;
     // for cases, pure string
-    var case2Reg = /[\?\.\s\:]/;
+    const case2Reg = /[\?\.\s\:]/;
     // for cases, data:uri and view-source:uri
-    var case3Reg = /^(data|view-source)\:/;
+    const case3Reg = /^\w+\:.*/;
 
-    var str = input.trim();
+    let str = input.trim();
     if (case1Reg.test(str) || !case2Reg.test(str) ||
         this.getScheme(str) === str) {
       return true;
@@ -69,7 +70,7 @@ export default class UrlUtil {
     }
 
     try {
-      var url = new URL(str);
+      let url = new URL(str);
       return !url;
     } catch(e) {
       return true;


### PR DESCRIPTION
I wrote some manual tests lol because https://github.com/cvan/urlutil.js/tree/tests was too complicated:

```
> UrlUtil.getUrlFromInput('localhost')
http://localhost/

> UrlUtil.getUrlFromInput('localhost:8000')
localhost:8000

> UrlUtil.getUrlFromInput('http://localhost')
http://localhost/

> UrlUtil.getUrlFromInput('http://localhost:8000')
http://localhost:8000/

> UrlUtil.getUrlFromInput('localhost')
http://localhost/

> UrlUtil.getUrlFromInput('127.0.0.1')
http://127.0.0.1/

> UrlUtil.getUrlFromInput('127.0.0.1:3000')
http://127.0.0.1:3000/

> UrlUtil.getUrlFromInput('view-source:http://localhost:3000')
view-source:http://localhost:3000
```
